### PR TITLE
Update documentation for newer Vault versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,10 @@ If you elect to build the plugin from Go modules in our GitHub repo, follow thes
 6. Register the `vault-plugin-secrets-datastax-astra` plugin in the Vault system catalog and use the version of the plugin you just downloaded:
 
 	```bash
-	vault plugin register -sha256=${SHA256} -command=vault-plugin-secrets-datastax-astra_1.0.0 -version=v1.0.0 secret vault-plugin-secrets-datastax-astra
+	vault plugin register -sha256=${SHA256} \
+	  -command=vault-plugin-secrets-datastax-astra_1.0.0 \
+	  -version=v1.0.0 \
+	  secret vault-plugin-secrets-datastax-astra
 	```
 
 	**Output:**
@@ -388,10 +391,13 @@ Follow these steps:
 ## Upgrade plugin from binary distribution
 Plugin versioning was introduced in Vault 1.12, allowing for a smooth upgrade of the plugin that has been mounted at a path on a running Vault server. These steps assume you have already registered the plugins as outlined under "Setup plugin from binary distribution".
 
-1. To upgrade the plugin, register a newer version of the plugin. You **must** use the same plugin type and name as the plugin being upgraded:
+1. To upgrade the plugin, register a newer version of the plugin. You **must** use the same plugin type (secret) and name (vault-plugin-secrets-datastax-astra) as the plugin being upgraded:
 
 	```bash
-	vault plugin register -sha256=${SHA256} -command=vault-plugin-secrets-datastax-astra_1.0.1 -version=v1.0.1 secret vault-plugin-secrets-datastax-astra
+	vault plugin register -sha256=${SHA256} \
+	  -command=vault-plugin-secrets-datastax-astra_1.0.1 \
+	  -version=v1.0.1 \
+	  secret vault-plugin-secrets-datastax-astra
 	```
 
 2. Tune the existing mount to configure it to use the newly registered version:

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ If you elect to build the plugin from Go modules in our GitHub repo, follow thes
 
 1. Create a plugins directory where HashiCorp Vault will find the plugin. Example: `./vault/plugins`.  **IMPORTANT:** do not specify a symlinked directory.
 
-2. Download the latest release Astra DB Plugin for HashiCorp Vault package for your operating system. In GitHub, navigate to the following directory, and click the relevant tarball to download it: https://github.com/datastax/vault-plugin-secrets-datastax-astra/releases/tag/v0.1.0. 
+2. Download the latest release Astra DB Plugin for HashiCorp Vault package for your operating system. In GitHub, navigate to the following directory, and click the relevant tarball to download it: https://github.com/datastax/vault-plugin-secrets-datastax-astra/releases/tag/v1.0.0.
 
 3. Unpack the binary and move its files to your plugin directory. 
 
@@ -138,14 +138,13 @@ If you elect to build the plugin from Go modules in our GitHub repo, follow thes
 5. Get the SHA-256 checksum of the plugin binary:
 
 	```bash
-	SHA256=$(sha256sum /private/etc/vault/plugins/vault-plugin-secrets-datastax-astra| cut -d' ' -f1)
+	SHA256=$(sha256sum /private/etc/vault/plugins/vault-plugin-secrets-datastax-astra_1.0.0 | cut -d' ' -f1)
 	```
 
-6. Register the `vault-plugin-secrets-datastax-astra` plugin in the Vault system catalog:
+6. Register the `vault-plugin-secrets-datastax-astra` plugin in the Vault system catalog and use the version of the plugin you just downloaded:
 
 	```bash
-	vault write sys/plugins/catalog/secret/vault-plugin-secrets-datastax-astra \
-	sha_256="${SHA256}" command="vault-plugin-secrets-datastax-astra"
+	vault plugin register -sha256=${SHA256} -command=vault-plugin-secrets-datastax-astra_1.0.0 -version=v1.0.0 secret vault-plugin-secrets-datastax-astra
 	```
 
 	**Output:**
@@ -385,6 +384,34 @@ Follow these steps:
 	```
 	Success! Data deleted (if it existed) at: astra/org/token
 	```
+
+## Upgrade plugin from binary distribution
+Plugin versioning was introduced in Vault 1.12, allowing for a smooth upgrade of the plugin that has been mounted at a path on a running Vault server. These steps assume you have already registered the plugins as outlined under "Setup plugin from binary distribution".
+
+1. To upgrade the plugin, register a newer version of the plugin. You **must** use the same plugin type and name as the plugin being upgraded:
+
+	```bash
+	vault plugin register -sha256=${SHA256} -command=vault-plugin-secrets-datastax-astra_1.0.1 -version=v1.0.1 secret vault-plugin-secrets-datastax-astra
+	```
+
+2. Tune the existing mount to configure it to use the newly registered version:
+
+	```bash
+	vault secrets tune -plugin-version=v1.0.1 vault-plugin-secrets-datastax-astra
+	```
+
+3. If you want, you can check the updated configuration. Notice the "Version" is now different from the "Running Version":
+
+	```bash
+	vault secrets list -detailed
+	```
+
+4. As the final step, trigger a plugin reload. This will reload all mounted backends using that plugin:
+
+	```bash
+	vault plugin reload -plugin vault-plugin-secrets-datastax-astra
+	```
+
 
 ## Summary
 


### PR DESCRIPTION
The documentation for the Datastax Vault plugin is using a syntax for registering plugins that a bit outdated. Newer versions of Vault support `vault plugin ...` CLI commands. This PR reflects these updated commands.

Also added a section about upgrading the plugin (from binary distribution).